### PR TITLE
Dont require trailing `:` to enforce semantic headings

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -8,67 +8,67 @@ See the readme for a [list of external rules](https://github.com/wooorm/remark-l
 
 ## Table of Contents
 
--   [Rules](#rules)
+*   [Rules](#rules)
 
-    -   [external](#external)
-    -   [reset](#reset)
-    -   [blockquote-indentation](#blockquote-indentation)
-    -   [checkbox-character-style](#checkbox-character-style)
-    -   [checkbox-content-indent](#checkbox-content-indent)
-    -   [code-block-style](#code-block-style)
-    -   [definition-case](#definition-case)
-    -   [definition-spacing](#definition-spacing)
-    -   [emphasis-marker](#emphasis-marker)
-    -   [fenced-code-flag](#fenced-code-flag)
-    -   [fenced-code-marker](#fenced-code-marker)
-    -   [file-extension](#file-extension)
-    -   [final-definition](#final-definition)
-    -   [final-newline](#final-newline)
-    -   [first-heading-level](#first-heading-level)
-    -   [hard-break-spaces](#hard-break-spaces)
-    -   [heading-increment](#heading-increment)
-    -   [heading-style](#heading-style)
-    -   [link-title-style](#link-title-style)
-    -   [list-item-bullet-indent](#list-item-bullet-indent)
-    -   [list-item-content-indent](#list-item-content-indent)
-    -   [list-item-indent](#list-item-indent)
-    -   [list-item-spacing](#list-item-spacing)
-    -   [maximum-heading-length](#maximum-heading-length)
-    -   [maximum-line-length](#maximum-line-length)
-    -   [no-auto-link-without-protocol](#no-auto-link-without-protocol)
-    -   [no-blockquote-without-caret](#no-blockquote-without-caret)
-    -   [no-consecutive-blank-lines](#no-consecutive-blank-lines)
-    -   [no-duplicate-definitions](#no-duplicate-definitions)
-    -   [no-duplicate-headings](#no-duplicate-headings)
-    -   [no-emphasis-as-heading](#no-emphasis-as-heading)
-    -   [no-file-name-articles](#no-file-name-articles)
-    -   [no-file-name-consecutive-dashes](#no-file-name-consecutive-dashes)
-    -   [no-file-name-irregular-characters](#no-file-name-irregular-characters)
-    -   [no-file-name-mixed-case](#no-file-name-mixed-case)
-    -   [no-file-name-outer-dashes](#no-file-name-outer-dashes)
-    -   [no-heading-content-indent](#no-heading-content-indent)
-    -   [no-heading-indent](#no-heading-indent)
-    -   [no-heading-punctuation](#no-heading-punctuation)
-    -   [no-html](#no-html)
-    -   [no-inline-padding](#no-inline-padding)
-    -   [no-literal-urls](#no-literal-urls)
-    -   [no-missing-blank-lines](#no-missing-blank-lines)
-    -   [no-multiple-toplevel-headings](#no-multiple-toplevel-headings)
-    -   [no-shell-dollars](#no-shell-dollars)
-    -   [no-shortcut-reference-image](#no-shortcut-reference-image)
-    -   [no-shortcut-reference-link](#no-shortcut-reference-link)
-    -   [no-table-indentation](#no-table-indentation)
-    -   [no-tabs](#no-tabs)
-    -   [no-undefined-references](#no-undefined-references)
-    -   [no-unused-definitions](#no-unused-definitions)
-    -   [ordered-list-marker-style](#ordered-list-marker-style)
-    -   [ordered-list-marker-value](#ordered-list-marker-value)
-    -   [rule-style](#rule-style)
-    -   [strong-marker](#strong-marker)
-    -   [table-cell-padding](#table-cell-padding)
-    -   [table-pipe-alignment](#table-pipe-alignment)
-    -   [table-pipes](#table-pipes)
-    -   [unordered-list-marker-style](#unordered-list-marker-style)
+    *   [external](#external)
+    *   [reset](#reset)
+    *   [blockquote-indentation](#blockquote-indentation)
+    *   [checkbox-character-style](#checkbox-character-style)
+    *   [checkbox-content-indent](#checkbox-content-indent)
+    *   [code-block-style](#code-block-style)
+    *   [definition-case](#definition-case)
+    *   [definition-spacing](#definition-spacing)
+    *   [emphasis-marker](#emphasis-marker)
+    *   [fenced-code-flag](#fenced-code-flag)
+    *   [fenced-code-marker](#fenced-code-marker)
+    *   [file-extension](#file-extension)
+    *   [final-definition](#final-definition)
+    *   [final-newline](#final-newline)
+    *   [first-heading-level](#first-heading-level)
+    *   [hard-break-spaces](#hard-break-spaces)
+    *   [heading-increment](#heading-increment)
+    *   [heading-style](#heading-style)
+    *   [link-title-style](#link-title-style)
+    *   [list-item-bullet-indent](#list-item-bullet-indent)
+    *   [list-item-content-indent](#list-item-content-indent)
+    *   [list-item-indent](#list-item-indent)
+    *   [list-item-spacing](#list-item-spacing)
+    *   [maximum-heading-length](#maximum-heading-length)
+    *   [maximum-line-length](#maximum-line-length)
+    *   [no-auto-link-without-protocol](#no-auto-link-without-protocol)
+    *   [no-blockquote-without-caret](#no-blockquote-without-caret)
+    *   [no-consecutive-blank-lines](#no-consecutive-blank-lines)
+    *   [no-duplicate-definitions](#no-duplicate-definitions)
+    *   [no-duplicate-headings](#no-duplicate-headings)
+    *   [no-emphasis-as-heading](#no-emphasis-as-heading)
+    *   [no-file-name-articles](#no-file-name-articles)
+    *   [no-file-name-consecutive-dashes](#no-file-name-consecutive-dashes)
+    *   [no-file-name-irregular-characters](#no-file-name-irregular-characters)
+    *   [no-file-name-mixed-case](#no-file-name-mixed-case)
+    *   [no-file-name-outer-dashes](#no-file-name-outer-dashes)
+    *   [no-heading-content-indent](#no-heading-content-indent)
+    *   [no-heading-indent](#no-heading-indent)
+    *   [no-heading-punctuation](#no-heading-punctuation)
+    *   [no-html](#no-html)
+    *   [no-inline-padding](#no-inline-padding)
+    *   [no-literal-urls](#no-literal-urls)
+    *   [no-missing-blank-lines](#no-missing-blank-lines)
+    *   [no-multiple-toplevel-headings](#no-multiple-toplevel-headings)
+    *   [no-shell-dollars](#no-shell-dollars)
+    *   [no-shortcut-reference-image](#no-shortcut-reference-image)
+    *   [no-shortcut-reference-link](#no-shortcut-reference-link)
+    *   [no-table-indentation](#no-table-indentation)
+    *   [no-tabs](#no-tabs)
+    *   [no-undefined-references](#no-undefined-references)
+    *   [no-unused-definitions](#no-unused-definitions)
+    *   [ordered-list-marker-style](#ordered-list-marker-style)
+    *   [ordered-list-marker-value](#ordered-list-marker-value)
+    *   [rule-style](#rule-style)
+    *   [strong-marker](#strong-marker)
+    *   [table-cell-padding](#table-cell-padding)
+    *   [table-pipe-alignment](#table-pipe-alignment)
+    *   [table-pipes](#table-pipes)
+    *   [unordered-list-marker-style](#unordered-list-marker-style)
 
 ## Rules
 
@@ -79,13 +79,12 @@ be null or undefined in order to be ignored.
 ### external
 
 ````md
-    <!-- Load more rules -->
-    ```json
-    {
-      "external": ["foo", "bar", "baz"]
-    }
-    ```
-
+        <!-- Load more rules -->
+        ```json
+        {
+          "external": ["foo", "bar", "baz"]
+        }
+        ```
 ````
 
 External contains a list of extra rules to load.
@@ -100,14 +99,13 @@ rules are also loaded.
 ### reset
 
 ````md
-    <!-- Explicitly activate rules: -->
-    ```json
-    {
-      "reset": true,
-      "final-newline": true
-    }
-    ```
-
+        <!-- Explicitly activate rules: -->
+        ```json
+        {
+          "reset": true,
+          "final-newline": true
+        }
+        ```
 ````
 
 By default, all rules are turned on unless explicitly set to `false`.
@@ -206,28 +204,28 @@ Options: `boolean`, default: `false`.
 ### code-block-style
 
 ````md
-      <!-- Valid, when set to `indented` or `consistent`, invalid when set to `fenced` -->
-         Hello
+          <!-- Valid, when set to `indented` or `consistent`, invalid when set to `fenced` -->
+             Hello
 
-      ...
+          ...
 
-         World
+             World
 
-      <!-- Valid, when set to `fenced` or `consistent`, invalid when set to `indented` -->
-      ```
-      Hello
-      ```
-      ...
-      ```bar
-      World
-      ```
-
-      <!-- Always invalid -->
+          <!-- Valid, when set to `fenced` or `consistent`, invalid when set to `indented` -->
+          ```
           Hello
-      ...
-      ```
-      World
-        ```
+          ```
+          ...
+          ```bar
+          World
+          ```
+
+          <!-- Always invalid -->
+              Hello
+          ...
+          ```
+          World
+            ```
 ````
 
   Warn when code-blocks do not adhere to a given style.
@@ -287,28 +285,28 @@ Options: `boolean`, default: `false`.
 ### fenced-code-flag
 
 ````md
-      <!-- Valid: -->
-      ```hello
-      world();
-      ```
+          <!-- Valid: -->
+          ```hello
+          world();
+          ```
 
-      <!-- Valid: -->
-         Hello
+          <!-- Valid: -->
+             Hello
 
-      <!-- Invalid: -->
-      ```
-      world();
-      ```
+          <!-- Invalid: -->
+          ```
+          world();
+          ```
 
-      <!-- Valid when given `{allowEmpty: true}`: -->
-      ```
-      world();
-      ```
+          <!-- Valid when given `{allowEmpty: true}`: -->
+          ```
+          world();
+          ```
 
-      <!-- Invalid when given `["world"]`: -->
-      ```hello
-      world();
-      ```
+          <!-- Invalid when given `["world"]`: -->
+          ```hello
+          world();
+          ```
 ````
 
   Warn when fenced code blocks occur without language flag.
@@ -326,32 +324,32 @@ Options: `boolean`, default: `false`.
 ### fenced-code-marker
 
 ````md
-      <!-- Valid by default and `` '`' ``: -->
-      ```foo
-      bar();
-      ```
+          <!-- Valid by default and `` '`' ``: -->
+          ```foo
+          bar();
+          ```
 
-      ```
-      baz();
-      ```
+          ```
+          baz();
+          ```
 
-      <!-- Valid by default and `'~'`: -->
-      ~~~foo
-      bar();
-      ~~~
+          <!-- Valid by default and `'~'`: -->
+          ~~~foo
+          bar();
+          ~~~
 
-      ~~~
-      baz();
-      ~~~
+          ~~~
+          baz();
+          ~~~
 
-      <!-- Always invalid: -->
-      ~~~foo
-      bar();
-      ~~~
+          <!-- Always invalid: -->
+          ~~~foo
+          bar();
+          ~~~
 
-      ```
-      baz();
-      ```
+          ```
+          baz();
+          ```
 ````
 
   Warn for violating fenced code markers.
@@ -756,18 +754,21 @@ Options: `boolean`, default: `false`.
 
 ```md
   <!-- Valid: -->
-  # Foo
+  # Foo:
 
   Bar.
 
   <!-- Invalid: -->
-  *Foo*
+  *Foo:*
 
   Bar.
 ```
 
   Warn when emphasis (including strong), instead of a heading, introduces
   a paragraph.
+
+  Currently, only warns when a colon (`:`) is also included, maybe that
+  could be omitted.
 
 ### no-file-name-articles
 
@@ -968,24 +969,24 @@ Options: `boolean`, default: `false`.
 ### no-shell-dollars
 
 ````md
-      <!-- Invalid: -->
-      ```bash
-      $ echo a
-      $ echo a > file
-      ```
+          <!-- Invalid: -->
+          ```bash
+          $ echo a
+          $ echo a > file
+          ```
 
-      <!-- Valid: -->
-      ```sh
-      echo a
-      echo a > file
-      ```
+          <!-- Valid: -->
+          ```sh
+          echo a
+          echo a > file
+          ```
 
-      <!-- Also valid: -->
-      ```zsh
-      $ echo a
-      a
-      $ echo a > file
-      ```
+          <!-- Also valid: -->
+          ```zsh
+          $ echo a
+          a
+          $ echo a > file
+          ```
 ````
 
   Warn when shell code is prefixed by dollar-characters.

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -8,67 +8,67 @@ See the readme for a [list of external rules](https://github.com/wooorm/remark-l
 
 ## Table of Contents
 
-*   [Rules](#rules)
+-   [Rules](#rules)
 
-    *   [external](#external)
-    *   [reset](#reset)
-    *   [blockquote-indentation](#blockquote-indentation)
-    *   [checkbox-character-style](#checkbox-character-style)
-    *   [checkbox-content-indent](#checkbox-content-indent)
-    *   [code-block-style](#code-block-style)
-    *   [definition-case](#definition-case)
-    *   [definition-spacing](#definition-spacing)
-    *   [emphasis-marker](#emphasis-marker)
-    *   [fenced-code-flag](#fenced-code-flag)
-    *   [fenced-code-marker](#fenced-code-marker)
-    *   [file-extension](#file-extension)
-    *   [final-definition](#final-definition)
-    *   [final-newline](#final-newline)
-    *   [first-heading-level](#first-heading-level)
-    *   [hard-break-spaces](#hard-break-spaces)
-    *   [heading-increment](#heading-increment)
-    *   [heading-style](#heading-style)
-    *   [link-title-style](#link-title-style)
-    *   [list-item-bullet-indent](#list-item-bullet-indent)
-    *   [list-item-content-indent](#list-item-content-indent)
-    *   [list-item-indent](#list-item-indent)
-    *   [list-item-spacing](#list-item-spacing)
-    *   [maximum-heading-length](#maximum-heading-length)
-    *   [maximum-line-length](#maximum-line-length)
-    *   [no-auto-link-without-protocol](#no-auto-link-without-protocol)
-    *   [no-blockquote-without-caret](#no-blockquote-without-caret)
-    *   [no-consecutive-blank-lines](#no-consecutive-blank-lines)
-    *   [no-duplicate-definitions](#no-duplicate-definitions)
-    *   [no-duplicate-headings](#no-duplicate-headings)
-    *   [no-emphasis-as-heading](#no-emphasis-as-heading)
-    *   [no-file-name-articles](#no-file-name-articles)
-    *   [no-file-name-consecutive-dashes](#no-file-name-consecutive-dashes)
-    *   [no-file-name-irregular-characters](#no-file-name-irregular-characters)
-    *   [no-file-name-mixed-case](#no-file-name-mixed-case)
-    *   [no-file-name-outer-dashes](#no-file-name-outer-dashes)
-    *   [no-heading-content-indent](#no-heading-content-indent)
-    *   [no-heading-indent](#no-heading-indent)
-    *   [no-heading-punctuation](#no-heading-punctuation)
-    *   [no-html](#no-html)
-    *   [no-inline-padding](#no-inline-padding)
-    *   [no-literal-urls](#no-literal-urls)
-    *   [no-missing-blank-lines](#no-missing-blank-lines)
-    *   [no-multiple-toplevel-headings](#no-multiple-toplevel-headings)
-    *   [no-shell-dollars](#no-shell-dollars)
-    *   [no-shortcut-reference-image](#no-shortcut-reference-image)
-    *   [no-shortcut-reference-link](#no-shortcut-reference-link)
-    *   [no-table-indentation](#no-table-indentation)
-    *   [no-tabs](#no-tabs)
-    *   [no-undefined-references](#no-undefined-references)
-    *   [no-unused-definitions](#no-unused-definitions)
-    *   [ordered-list-marker-style](#ordered-list-marker-style)
-    *   [ordered-list-marker-value](#ordered-list-marker-value)
-    *   [rule-style](#rule-style)
-    *   [strong-marker](#strong-marker)
-    *   [table-cell-padding](#table-cell-padding)
-    *   [table-pipe-alignment](#table-pipe-alignment)
-    *   [table-pipes](#table-pipes)
-    *   [unordered-list-marker-style](#unordered-list-marker-style)
+    -   [external](#external)
+    -   [reset](#reset)
+    -   [blockquote-indentation](#blockquote-indentation)
+    -   [checkbox-character-style](#checkbox-character-style)
+    -   [checkbox-content-indent](#checkbox-content-indent)
+    -   [code-block-style](#code-block-style)
+    -   [definition-case](#definition-case)
+    -   [definition-spacing](#definition-spacing)
+    -   [emphasis-marker](#emphasis-marker)
+    -   [fenced-code-flag](#fenced-code-flag)
+    -   [fenced-code-marker](#fenced-code-marker)
+    -   [file-extension](#file-extension)
+    -   [final-definition](#final-definition)
+    -   [final-newline](#final-newline)
+    -   [first-heading-level](#first-heading-level)
+    -   [hard-break-spaces](#hard-break-spaces)
+    -   [heading-increment](#heading-increment)
+    -   [heading-style](#heading-style)
+    -   [link-title-style](#link-title-style)
+    -   [list-item-bullet-indent](#list-item-bullet-indent)
+    -   [list-item-content-indent](#list-item-content-indent)
+    -   [list-item-indent](#list-item-indent)
+    -   [list-item-spacing](#list-item-spacing)
+    -   [maximum-heading-length](#maximum-heading-length)
+    -   [maximum-line-length](#maximum-line-length)
+    -   [no-auto-link-without-protocol](#no-auto-link-without-protocol)
+    -   [no-blockquote-without-caret](#no-blockquote-without-caret)
+    -   [no-consecutive-blank-lines](#no-consecutive-blank-lines)
+    -   [no-duplicate-definitions](#no-duplicate-definitions)
+    -   [no-duplicate-headings](#no-duplicate-headings)
+    -   [no-emphasis-as-heading](#no-emphasis-as-heading)
+    -   [no-file-name-articles](#no-file-name-articles)
+    -   [no-file-name-consecutive-dashes](#no-file-name-consecutive-dashes)
+    -   [no-file-name-irregular-characters](#no-file-name-irregular-characters)
+    -   [no-file-name-mixed-case](#no-file-name-mixed-case)
+    -   [no-file-name-outer-dashes](#no-file-name-outer-dashes)
+    -   [no-heading-content-indent](#no-heading-content-indent)
+    -   [no-heading-indent](#no-heading-indent)
+    -   [no-heading-punctuation](#no-heading-punctuation)
+    -   [no-html](#no-html)
+    -   [no-inline-padding](#no-inline-padding)
+    -   [no-literal-urls](#no-literal-urls)
+    -   [no-missing-blank-lines](#no-missing-blank-lines)
+    -   [no-multiple-toplevel-headings](#no-multiple-toplevel-headings)
+    -   [no-shell-dollars](#no-shell-dollars)
+    -   [no-shortcut-reference-image](#no-shortcut-reference-image)
+    -   [no-shortcut-reference-link](#no-shortcut-reference-link)
+    -   [no-table-indentation](#no-table-indentation)
+    -   [no-tabs](#no-tabs)
+    -   [no-undefined-references](#no-undefined-references)
+    -   [no-unused-definitions](#no-unused-definitions)
+    -   [ordered-list-marker-style](#ordered-list-marker-style)
+    -   [ordered-list-marker-value](#ordered-list-marker-value)
+    -   [rule-style](#rule-style)
+    -   [strong-marker](#strong-marker)
+    -   [table-cell-padding](#table-cell-padding)
+    -   [table-pipe-alignment](#table-pipe-alignment)
+    -   [table-pipes](#table-pipes)
+    -   [unordered-list-marker-style](#unordered-list-marker-style)
 
 ## Rules
 
@@ -79,12 +79,13 @@ be null or undefined in order to be ignored.
 ### external
 
 ````md
-        <!-- Load more rules -->
-        ```json
-        {
-          "external": ["foo", "bar", "baz"]
-        }
-        ```
+    <!-- Load more rules -->
+    ```json
+    {
+      "external": ["foo", "bar", "baz"]
+    }
+    ```
+
 ````
 
 External contains a list of extra rules to load.
@@ -99,13 +100,14 @@ rules are also loaded.
 ### reset
 
 ````md
-        <!-- Explicitly activate rules: -->
-        ```json
-        {
-          "reset": true,
-          "final-newline": true
-        }
-        ```
+    <!-- Explicitly activate rules: -->
+    ```json
+    {
+      "reset": true,
+      "final-newline": true
+    }
+    ```
+
 ````
 
 By default, all rules are turned on unless explicitly set to `false`.
@@ -204,28 +206,28 @@ Options: `boolean`, default: `false`.
 ### code-block-style
 
 ````md
-          <!-- Valid, when set to `indented` or `consistent`, invalid when set to `fenced` -->
-             Hello
+      <!-- Valid, when set to `indented` or `consistent`, invalid when set to `fenced` -->
+         Hello
 
-          ...
+      ...
 
-             World
+         World
 
-          <!-- Valid, when set to `fenced` or `consistent`, invalid when set to `indented` -->
-          ```
+      <!-- Valid, when set to `fenced` or `consistent`, invalid when set to `indented` -->
+      ```
+      Hello
+      ```
+      ...
+      ```bar
+      World
+      ```
+
+      <!-- Always invalid -->
           Hello
-          ```
-          ...
-          ```bar
-          World
-          ```
-
-          <!-- Always invalid -->
-              Hello
-          ...
-          ```
-          World
-            ```
+      ...
+      ```
+      World
+        ```
 ````
 
   Warn when code-blocks do not adhere to a given style.
@@ -285,28 +287,28 @@ Options: `boolean`, default: `false`.
 ### fenced-code-flag
 
 ````md
-          <!-- Valid: -->
-          ```hello
-          world();
-          ```
+      <!-- Valid: -->
+      ```hello
+      world();
+      ```
 
-          <!-- Valid: -->
-             Hello
+      <!-- Valid: -->
+         Hello
 
-          <!-- Invalid: -->
-          ```
-          world();
-          ```
+      <!-- Invalid: -->
+      ```
+      world();
+      ```
 
-          <!-- Valid when given `{allowEmpty: true}`: -->
-          ```
-          world();
-          ```
+      <!-- Valid when given `{allowEmpty: true}`: -->
+      ```
+      world();
+      ```
 
-          <!-- Invalid when given `["world"]`: -->
-          ```hello
-          world();
-          ```
+      <!-- Invalid when given `["world"]`: -->
+      ```hello
+      world();
+      ```
 ````
 
   Warn when fenced code blocks occur without language flag.
@@ -324,32 +326,32 @@ Options: `boolean`, default: `false`.
 ### fenced-code-marker
 
 ````md
-          <!-- Valid by default and `` '`' ``: -->
-          ```foo
-          bar();
-          ```
+      <!-- Valid by default and `` '`' ``: -->
+      ```foo
+      bar();
+      ```
 
-          ```
-          baz();
-          ```
+      ```
+      baz();
+      ```
 
-          <!-- Valid by default and `'~'`: -->
-          ~~~foo
-          bar();
-          ~~~
+      <!-- Valid by default and `'~'`: -->
+      ~~~foo
+      bar();
+      ~~~
 
-          ~~~
-          baz();
-          ~~~
+      ~~~
+      baz();
+      ~~~
 
-          <!-- Always invalid: -->
-          ~~~foo
-          bar();
-          ~~~
+      <!-- Always invalid: -->
+      ~~~foo
+      bar();
+      ~~~
 
-          ```
-          baz();
-          ```
+      ```
+      baz();
+      ```
 ````
 
   Warn for violating fenced code markers.
@@ -754,21 +756,18 @@ Options: `boolean`, default: `false`.
 
 ```md
   <!-- Valid: -->
-  # Foo:
+  # Foo
 
   Bar.
 
   <!-- Invalid: -->
-  *Foo:*
+  *Foo*
 
   Bar.
 ```
 
   Warn when emphasis (including strong), instead of a heading, introduces
   a paragraph.
-
-  Currently, only warns when a colon (`:`) is also included, maybe that
-  could be omitted.
 
 ### no-file-name-articles
 
@@ -969,24 +968,24 @@ Options: `boolean`, default: `false`.
 ### no-shell-dollars
 
 ````md
-          <!-- Invalid: -->
-          ```bash
-          $ echo a
-          $ echo a > file
-          ```
+      <!-- Invalid: -->
+      ```bash
+      $ echo a
+      $ echo a > file
+      ```
 
-          <!-- Valid: -->
-          ```sh
-          echo a
-          echo a > file
-          ```
+      <!-- Valid: -->
+      ```sh
+      echo a
+      echo a > file
+      ```
 
-          <!-- Also valid: -->
-          ```zsh
-          $ echo a
-          a
-          $ echo a > file
-          ```
+      <!-- Also valid: -->
+      ```zsh
+      $ echo a
+      a
+      $ echo a > file
+      ```
 ````
 
   Warn when shell code is prefixed by dollar-characters.

--- a/lib/rules/no-emphasis-as-heading.js
+++ b/lib/rules/no-emphasis-as-heading.js
@@ -6,17 +6,14 @@
  * @fileoverview
  *   Warn when emphasis (including strong), instead of a heading, introduces
  *   a paragraph.
- *
- *   Currently, only warns when a colon (`:`) is also included, maybe that
- *   could be omitted.
  * @example
  *   <!-- Valid: -->
- *   # Foo:
+ *   # Foo
  *
  *   Bar.
  *
  *   <!-- Invalid: -->
- *   *Foo:*
+ *   *Foo*
  *
  *   Bar.
  */
@@ -61,16 +58,7 @@ function noEmphasisAsHeading(ast, file, preferred, done) {
             children.length === 1 &&
             (child.type === 'emphasis' || child.type === 'strong')
         ) {
-            value = toString(child);
-
-            /*
-             * TODO: See if removing the punctuation
-             * necessity is possible?
-             */
-
-            if (value.charAt(value.length - 1) === ':') {
-                file.warn('Don’t use emphasis to introduce a section, use a heading', node);
-            }
+          file.warn('Don’t use emphasis to introduce a section, use a heading', node);
         }
     });
 

--- a/lib/rules/no-emphasis-as-heading.js
+++ b/lib/rules/no-emphasis-as-heading.js
@@ -27,7 +27,6 @@
  */
 
 var visit = require('unist-util-visit');
-var toString = require('mdast-util-to-string');
 var position = require('mdast-util-position');
 
 /**
@@ -45,7 +44,6 @@ function noEmphasisAsHeading(ast, file, preferred, done) {
         var child = children[0];
         var prev = parent.children[index - 1];
         var next = parent.children[index + 1];
-        var value;
 
         if (position.generated(node)) {
             return;

--- a/lib/rules/no-emphasis-as-heading.js
+++ b/lib/rules/no-emphasis-as-heading.js
@@ -56,7 +56,7 @@ function noEmphasisAsHeading(ast, file, preferred, done) {
             children.length === 1 &&
             (child.type === 'emphasis' || child.type === 'strong')
         ) {
-          file.warn('Don’t use emphasis to introduce a section, use a heading', node);
+            file.warn('Don’t use emphasis to introduce a section, use a heading', node);
         }
     });
 

--- a/test/fixtures/no-emphasis-as-heading-invalid.md
+++ b/test/fixtures/no-emphasis-as-heading-invalid.md
@@ -1,7 +1,7 @@
-**How to make omelets:**
+**How to make omelets**
 
 Break an egg.
 
-*How to bake bread:*
+*How to bake bread*
 
 Open the flour sack.

--- a/test/fixtures/no-emphasis-as-heading-valid.md
+++ b/test/fixtures/no-emphasis-as-heading-valid.md
@@ -8,6 +8,9 @@ Open the flour sack.
 
 *And this is valid*
 
+* One
+* Two
+
 This is also valid:
 
     foo

--- a/test/index.js
+++ b/test/index.js
@@ -703,8 +703,8 @@ describe('Rules', function () {
     describeRule('no-emphasis-as-heading', function () {
         describeSetting(true, function () {
             assertFile('no-emphasis-as-heading-invalid.md', [
-                'no-emphasis-as-heading-invalid.md:1:1-1:25: Don’t use emphasis to introduce a section, use a heading',
-                'no-emphasis-as-heading-invalid.md:5:1-5:21: Don’t use emphasis to introduce a section, use a heading'
+                'no-emphasis-as-heading-invalid.md:1:1-1:24: Don’t use emphasis to introduce a section, use a heading',
+                'no-emphasis-as-heading-invalid.md:5:1-5:20: Don’t use emphasis to introduce a section, use a heading'
             ]);
 
             assertFile('no-emphasis-as-heading-valid.md', []);


### PR DESCRIPTION
This pull request removes the requirement that emphasis-based headings must have trailing punctuation in order to be flagged as invalid to more aggressively enforce semantic headings. I can't think of when this would cause a false positive, if on a line by itself.

It seems strange to me, that the rule's documentation states that `# test:` would be valid, even though that would conflict with `no-heading-punctuation`.