### PR TITLE
Support Electron environment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@ var fs = require('fs');
 var exists = fs && fs.existsSync;
 var resolve = path && path.resolve;
 var isWindows;
+var isElectron;
 var isGlobal;
 var globals;
 var cwd;
@@ -49,7 +50,8 @@ if (typeof global !== 'undefined') {
 
     /* Detect whether we’re running as a globally installed package. */
     isWindows = global.process.platform === 'win32';
-    isGlobal = global.process.argv[1].indexOf(npmPrefix) === 0;
+    isElectron = global.process.versions.electron !== undefined;
+    isGlobal = isElectron || global.process.argv[1].indexOf(npmPrefix) === 0;
 
     /* istanbul ignore next */
     globals = resolve(npmPrefix, isWindows ? '' : 'lib', MODULES);


### PR DESCRIPTION
Electron app runs on Node.js environment, so `isGlobal` should be `true`.  But Electron app has its own binary to execute.  Its `process.argv` will be `['/path/to/MyApp']`, not `['/path/to/node', '/path/to/entrypoint.js']`.  So we can't detect Electron app from `process.argv[1]`.

Instead, we can do that with existence of `process.versions.electron`.  It will not be `undefined` only in Electron environment.
This change will not break other environment because of just adding above check.

This fix will make remark-lint detect Electron environment as Node.js environment correctly.

### Already Checked

- Build and linter passed
- All test passed
- Coverage 100%
- [Tried in my Electron app](https://github.com/rhysd/Shiba/blob/master/package.json#L39)

### My Environemnt
  - Node.js 5.9.0
  - Electron 0.37.2
  - OS X 10.11.4
