### PR TITLE
Added `remark-lint-ending-period` into the external rules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -210,6 +210,9 @@ excluding `remark-lint-no-` or `remark-lint-`
 *   [`vhf/remark-lint-no-url-trailing-slash`](https://github.com/vhf/remark-lint-no-url-trailing-slash)
     — Ensure that the `href` of links has no trailing slash.
 
+*   [`wemake-services/remark-lint-ending-period`](https://github.com/wemake-services/remark-lint-ending-period)
+    — Ensure that all list items are ended with the certain set of symbols.
+
 ## Related
 
 *   [`wooorm/remark-validate-links`](https://github.com/wooorm/remark-validate-links)


### PR DESCRIPTION
See the project's page: https://github.com/wemake-services/remark-lint-ending-period

The idea behind it was, that I need my list-items in the [`awesome-cryptography`](https://github.com/sobolevn/awesome-cryptography) to be closed with the `.` char.

We have added the support of any other set of symbols, such as: `[';', '...', '!']`, see it in action: https://github.com/sobolevn/awesome-cryptography/blob/master/package.json