### PR TITLE
no-file-name-articles: forbid "teh"

### DIFF
--- a/packages/remark-lint/lib/rules/no-file-name-articles.js
+++ b/packages/remark-lint/lib/rules/no-file-name-articles.js
@@ -33,7 +33,7 @@ module.exports = noFileNameArticles;
  * @param {File} file - Virtual file.
  */
 function noFileNameArticles(ast, file) {
-  var match = file.stem && file.stem.match(/^(the|an?)\b/i);
+  var match = file.stem && file.stem.match(/^(the|teh|an?)\b/i);
 
   if (match) {
     file.message('Do not start file names with `' + match[0] + '`');


### PR DESCRIPTION
It is sometimes used as an alternative to "the", so `no-file-name-articles` rule should probably also forbid it when forbidding "the".

Wiki reference: https://en.wikipedia.org/wiki/Teh.

:wink: 