### PR TITLE
Added remark-lint-appropriate-heading to plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,8 @@ excluding `remark-lint-no-` or `remark-lint-`
 
 *   [`vhf/remark-lint-alphabetize-lists`](https://github.com/vhf/remark-lint-alphabetize-lists)
     — Ensure list items are in alphabetical order;
+*   [`RichardLitt/remark-lint-appropriate-heading](https://github.com/RichardLitt/remark-lint-appropriate-heading)
+    - Check that the top-level heading matches the directory name;
 *   [`vhf/remark-lint-blank-lines-1-0-2`](https://github.com/vhf/remark-lint-blank-lines-1-0-2)
     — Ensure a specific number of lines between blocks;
 *   [`vhf/remark-lint-books-links`](https://github.com/vhf/remark-lint-books-links)


### PR DESCRIPTION
see https://github.com/wooorm/remark/pull/217#issuecomment-267150813